### PR TITLE
Tests für Statistik-kompatible Navigation durch Suchergebnisse

### DIFF
--- a/tests/pagination/FrontdoorPaginationTest.php
+++ b/tests/pagination/FrontdoorPaginationTest.php
@@ -114,6 +114,35 @@ class FrontdoorPaginationTest extends TestCase {
         $this->assertText('//span[@id="pagination-current-hit"]', '5');
         $this->assertText('//span[@id="pagination-num-hits"]', '10');
     }
+    
+    public function testClickNextUrlContainsParameterNavWithValueNext() {
+
+        $frontdoorLink = "/frontdoor/index/index/searchtype/all/start/1/rows/10/docId/305";
+        $this->openAndWait($frontdoorLink);
+        $this->clickAndWait('//li[@id="pagination-next"]/a');
+        $url = $this->getLocation();
+        $this->assertTrue(strpos($url, 'nav/next') !== false, "Parameter 'nav' with value 'next' not present");
+
+    }
+
+    public function testClickPreviousUrlContainsParameterNavWithValuePrev() {
+
+        $frontdoorLink = "/frontdoor/index/index/searchtype/all/start/1/rows/10/docId/305";
+        $this->openAndWait($frontdoorLink);
+        $this->clickAndWait('//li[@id="pagination-previous"]/a');
+        $url = $this->getLocation();
+        $this->assertTrue(strpos($url, 'nav/prev') !== false, "Parameter 'nav' with value 'prev' not present");
+
+    }
+
+    public function testClickNextUrlContainsDocId() {
+
+        $frontdoorLink = "/frontdoor/index/index/searchtype/all/start/1/rows/10/docId/305";
+        $this->openAndWait($frontdoorLink);
+        $this->clickAndWait('//li[@id="pagination-next"]/a');
+        $url = $this->getLocation();
+        $this->assertTrue(strpos($url, 'docId') !== false, "Parameter 'docId' not present");
+    }
 
     protected function frontdoorLinkExists($number, $href) {
         return $this->isElementPresent('//dl[contains(concat(" ", normalize-space(@class), " "), " result_box ")][' . $number . ']/dt[contains(concat(" ", normalize-space(@class), " "), " results_title ")]/a[contains(@href,"' . $href . '")]');

--- a/tests/pagination/FrontdoorPaginationTest.php
+++ b/tests/pagination/FrontdoorPaginationTest.php
@@ -114,7 +114,7 @@ class FrontdoorPaginationTest extends TestCase {
         $this->assertText('//span[@id="pagination-current-hit"]', '5');
         $this->assertText('//span[@id="pagination-num-hits"]', '10');
     }
-    
+
     public function testClickNextUrlContainsParameterNavWithValueNext() {
 
         $frontdoorLink = "/frontdoor/index/index/searchtype/all/start/1/rows/10/docId/305";
@@ -122,7 +122,6 @@ class FrontdoorPaginationTest extends TestCase {
         $this->clickAndWait('//li[@id="pagination-next"]/a');
         $url = $this->getLocation();
         $this->assertTrue(strpos($url, 'nav/next') !== false, "Parameter 'nav' with value 'next' not present");
-
     }
 
     public function testClickPreviousUrlContainsParameterNavWithValuePrev() {
@@ -132,7 +131,6 @@ class FrontdoorPaginationTest extends TestCase {
         $this->clickAndWait('//li[@id="pagination-previous"]/a');
         $url = $this->getLocation();
         $this->assertTrue(strpos($url, 'nav/prev') !== false, "Parameter 'nav' with value 'prev' not present");
-
     }
 
     public function testClickNextUrlContainsDocId() {
@@ -142,6 +140,18 @@ class FrontdoorPaginationTest extends TestCase {
         $this->clickAndWait('//li[@id="pagination-next"]/a');
         $url = $this->getLocation();
         $this->assertTrue(strpos($url, 'docId') !== false, "Parameter 'docId' not present");
+    }
+
+    public function testWrongUrlDocIDRedirectsToRightDocIdUrl() {
+
+        $frontdoorLink = "/frontdoor/index/index/searchtype/latest/docId/306/start/4/rows/10";
+        $this->openAndWait($frontdoorLink);
+
+        $url = $this->getLocation();
+
+        $this->assertFalse(strpos($url, 'docId/306') !== false, "Wrong docId in URL");
+        $this->assertTrue(strpos($url, 'docId/150') !== false, "Correct docId not found in URL");
+
     }
 
     protected function frontdoorLinkExists($number, $href) {


### PR DESCRIPTION
Hier sind 3 Tests, die die Umsetzung der Anforderungen für die "statistik-kompatible Trefferweiterschaltung" abdecken sollten: das Vorhandensein der docId und des Parameters "nav" mit den Werten "prev" bzw. "next".
